### PR TITLE
Ensure cluster size table is a data frame

### DIFF
--- a/R/store.dht.results.R
+++ b/R/store.dht.results.R
@@ -37,7 +37,8 @@ store.dht.results <- function(results, dht.results, i, clusters, data, obs.tab, 
       results$clusters$summary[strat,c("Area", "CoveredArea", "Effort", "n", "k", "ER", "se.ER", "cv.ER"),i] <- as.matrix(dht.results$clusters$summary[dht.results$clusters$summary$Region == strata.names[strat],c("Area", "CoveredArea", "Effort", "n", "k", "ER", "se.ER", "cv.ER")])
       results$clusters$N[strat,c("Estimate", "se", "cv", "lcl", "ucl", "df"),i] <- as.matrix(dht.results$clusters$N[dht.results$clusters$N$Label == strata.names.ND[strat],c("Estimate", "se", "cv", "lcl", "ucl", "df")])
       results$clusters$D[strat,c("Estimate", "se", "cv", "lcl", "ucl", "df"),i] <- as.matrix(dht.results$clusters$D[dht.results$clusters$D$Label == strata.names.ND[strat],c("Estimate", "se", "cv", "lcl", "ucl", "df")])
-      results$expected.size[strat, c("Expected.S","se.Expected.S"), i] <- as.matrix(dht.results$Expected.S[dht.results$Expected.S$Region == strata.names.ND[strat], c("Expected.S","se.Expected.S")])[1,]
+      # Needed to add and as.data.frame as this table had turned into a list at some point
+      results$expected.size[strat, c("Expected.S","se.Expected.S"), i] <- as.matrix(as.data.frame(dht.results$Expected.S)[dht.results$Expected.S$Region == strata.names.ND[strat], c("Expected.S","se.Expected.S")])[1,]
     }
   }
   return(results)


### PR DESCRIPTION
The output from mrds / Distance appears to have changed this has been reported as an [issue](https://github.com/DistanceDevelopment/mrds/issues/54) in mrds but this change means that dsims will work despite this.